### PR TITLE
Fixes NPE on empty scopes

### DIFF
--- a/src/main/java/org/honton/chas/license/maven/plugin/ScopeMatcher.java
+++ b/src/main/java/org/honton/chas/license/maven/plugin/ScopeMatcher.java
@@ -26,6 +26,9 @@ public class ScopeMatcher {
    * @return true, if the artifact matches
    */
   public boolean isMatch(String scope) {
+    if (scope == null) {
+      return false;
+    }
     return 0 <= Arrays.binarySearch(scopes, scope);
   }
 }


### PR DESCRIPTION
Some broken dependencies don't have a scope, failing with a NPE